### PR TITLE
Adding better decoration for check history metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Enhaced history metrics: outputs all history metrics into a single measurement, adding subscribers and check name as tags
+
 ### Added
 - Proxy_mode
 - Basic auth authentication option.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Note that :
 * `buffer_max_size` : buffer size limit before flush - This is the amount of points in the InfluxDB batch - (default is `500`)
 * `buffer_max_age` : buffer maximum age - Flush will be forced after this amount of time - (default is `6` seconds)
 * `Proxy mode` : If the extension is configured to be in proxy mode, it will skip the transformation step and assume that the data is valid [line protocol](https://docs.influxdata.com/influxdb/latest/write_protocols/line_protocol_reference). It will not take into account any tags defined in the sensu-configuration.
+* `enhanced_history`: by default this extension writes checks history as separated measurements on InfluxDB. Setting this attribute to true will write all check history in the same metric (sensu.checks), tagging check name and subscriptions, allowing the user to write InfluxDB queries filtering by check name and subscriptions.
 
 ## Check options
 


### PR DESCRIPTION
- [x] Updated readme
- [x] Updated changelog
- [x] Rubocop passes

This extension is able to send metrics regarding check results to InfluxDB. The format used is to create a measurement per check, which is not optimal when it comes to build InfluxDB queries and/or build dashboards based on those queries.

With this PR, a new configuration option is available (enhanced_history), which toggles this behavior in favor of a different approach: all check history will be stored within the same InfluxDB measurement, adding a tag for the check name and another tag for all subscriptions which the check belongs to. In other words, it will be pretty easy to run queries filtering by check name or subscription, as InfluxDB doesn't allow to filter by measurement name.

The default behavior hasn't changed to allow backwards compatibility.